### PR TITLE
Core/Spells: Fixed SPELL_EFFECT_DISPEL when target has 2 spells with same ID

### DIFF
--- a/src/server/game/Spells/SpellEffects.cpp
+++ b/src/server/game/Spells/SpellEffects.cpp
@@ -2116,7 +2116,7 @@ void Spell::EffectDispel(SpellEffIndex effIndex)
         {
             auto successItr = std::find_if(successList.begin(), successList.end(), [&itr](DispelableAura& dispelAura) -> bool
             {
-                if (dispelAura.GetAura()->GetId() == itr->GetAura()->GetId())
+                if (dispelAura.GetAura()->GetId() == itr->GetAura()->GetId() && dispelAura.GetAura()->GetCaster() == itr->GetAura()->GetCaster())
                     return true;
 
                 return false;


### PR DESCRIPTION
https://github.com/TrinityCore/TrinityCore/commit/95284b23d1e48883fe738ecf5a12c4253566894e