### PR TITLE
Core/Spells: improve random radius calculation

### DIFF
--- a/src/server/game/Spells/SpellInfo.cpp
+++ b/src/server/game/Spells/SpellInfo.cpp
@@ -802,7 +802,7 @@ float SpellEffectInfo::CalcRadius(WorldObject* caster /*= nullptr*/, SpellTarget
     if (target.GetTarget() == TARGET_DEST_CASTER_RANDOM ||
         target.GetTarget() == TARGET_DEST_TARGET_RANDOM ||
         target.GetTarget() == TARGET_DEST_DEST_RANDOM)
-        radius += (entry->RadiusMax - radius) * rand_norm();
+        radius += (entry->RadiusMax - radius) * std::sqrtf(rand_norm());
     else if (radius == 0.0f)
         radius = entry->RadiusMax;
 


### PR DESCRIPTION
**Changes proposed:**

We will now evenly distribute the random distance accross the entirely of the radius by reducing the chance of lower values the closer we get to the center. This prevents clumping near the center and ensures that any point within the radius has an equal chance of getting hit.

This can be observed in Slabhide's encounter when he will summon several rocks falling from the ceiling. Without this change, the rocks will start to clump near the center because they get closer to each other

Here is a test case with 50 samples which highlight the change:

Without square root values:
```
0.19465029
0.22782743
0.44440538
0.5340579
0.5815795
0.5902818
0.62190056
0.6225696
0.7251525
0.7645908
0.807721
0.92431724
0.9903851
1.2174001
1.4950597
1.5047607
1.5985284
1.6476085
1.8352389
1.9021088
1.9949505
2.061167
2.30939
2.562699
2.5808766
2.6488862
2.6659193
2.7002287
2.739142
2.8724992
3.0296817
3.1732318
3.2575278
3.3647132
3.4506145
3.4854352
3.4941652
3.6498575
3.6562347
3.884427
3.935795
4.001766
4.1130953
4.192279
4.5204144
4.5695662
4.685139
4.6908927
4.695736
4.859196
```

With square root random values:
```
0.5356342
0.76309764
0.9300412
1.0417225
1.0616132
1.437624
1.8746912
1.8864177
1.9963871
2.3394022
2.3603332
2.4785094
2.498258
2.5813997
2.5860703
2.6058788
2.771773
2.8289592
3.015324
3.0222836
3.1003165
3.1465576
3.2561815
3.31561
3.3856704
3.4070153
3.4855561
3.5115557
3.6186554
3.6344151
3.658032
3.663113
3.676686
3.7327375
3.8075762
3.9197338
3.9203982
3.9339793
4.0212317
4.0849338
4.1623693
4.1780014
4.1964617
4.2303567
4.252023
4.3089714
4.4600453
4.5123515
4.6280937
4.9315977
```

Why is this important?:
<img width="544" height="474" alt="grafik" src="https://github.com/user-attachments/assets/7d2c3aef-a14f-4f78-8b86-f8f15ca6e7e5" />

This image highlights that the closer we get the center of a circle, the more likely it is for points to overlap, so naturally we want to prevent this from happening By using sqrt, we push lower numbers further out so that outer numbers are more likely, resulting in fewer clumps from forming

**Tests performed:**
tested ingame
